### PR TITLE
City Precedence in GetCityFromCoordinatesAsync:74

### DIFF
--- a/GuigleAPI/GoogleGeocodingAPI.cs
+++ b/GuigleAPI/GoogleGeocodingAPI.cs
@@ -71,7 +71,7 @@ namespace GuigleAPI
 
                 var addressComponentes = contentResult.Results.SelectMany(t => t.AddressComponents);
 
-                var city = addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.administrative_area_level_2.ToString()))?.ShortName ?? addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.administrative_area_level_3.ToString()))?.ShortName ?? addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.locality.ToString()))?.ShortName;
+                var city = addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.locality.ToString()))?.ShortName?? addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.administrative_area_level_2.ToString()))?.ShortName ?? addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.administrative_area_level_3.ToString()))?.ShortName;
                 var state = addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.administrative_area_level_1.ToString()))?.ShortName;
                 var country = addressComponentes.FirstOrDefault(r => r.Types.Contains(AddressType.country.ToString()))?.LongName;
 


### PR DESCRIPTION
The order of precedence on what should be considered a is reversed. The city should first be the "locality" if provided. If not then administrative area level 2 should be used. Finally, administrative area level 3 should be used.